### PR TITLE
V2 - more intuitive sampling api

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install --save atlas-basic-timer
 
 I have re-written simple timer scripts so many times, I figured I'd just write a basic timer to use. This timer is simple -- it takes a task and a number of iterations, and tells you how long it ran in nanoseconds (not guaranteed to be accurate to nanoseconds, but uses `process.hrtime` if it's available).
 
-Optionally, you can use `stat` mode to obtain **more detailed statistics**, such as the mean and standard deviation.
+Optionally, you can run each task with a number of samples, in which case the iterations will be run `samples`  times, for a total of `n * samples` tasks run.
 
 ## examples
 
@@ -42,6 +42,22 @@ const durationNanosecs = myTimer(myTask)
 const myTimer = Timer({n: 1000});
 const durationNanosecs = myTimer(myTask)
 // ~$ myTask x 1000 took 15.475ms
+```
+
+#### specify a number of samples
+
+```javascript
+...
+// we want 10 samples
+const stats = myTimer(myTask, 10);
+// ~$ myTask x 1000 (x 10) took 98.342ms (9.444ms +/- 1.840ms)
+console.log(stats)
+// { size: 10,
+//   total: 98342047,   // total elapsed time to run 1000x10
+//   mean: 9834204.7,
+//   median: 9444400.5,
+//   mad: 1839641.5,    // median absolute deviation
+//   stddev: 2416776.9310497018 }
 ```
 
 #### run async timing tests
@@ -85,23 +101,4 @@ Note that the `durationNanosecs` return value will never be rounded, only the lo
 // we don't want to log anything to the console
 const myTimer = Timer({log: false, n: 1000})
 const durationNanosecs = myTimer(myTask)
-```
-
-#### getting more stats
-
-```javascript
-...
-// get more than just the elapsed time
-const myTimer = Timer({stat: true, n: 1000})
-const stats = myTimer(myTask);
-// ~$ myTask x 1000 took 15.474757ms (12.432us +/- 1.321us)
-console.log(stats)
-// {
-//   size: 1000,
-//   total: 15474757,   // total elapsed time
-//   mean: 15474.757,
-//   stddev: 5482.2874,
-//   median: 12432.234,
-//   mad: 1321.21124    // median absolute deviation
-// }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-basic-timer",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-basic-timer",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "A basic timer for performance testing which uses high resolution time and falls back to low resolution if required.",
   "scripts": {
     "test-server": "mocha --colors --watch --recursive './test/**/*.test.js'",

--- a/src/Timer.js
+++ b/src/Timer.js
@@ -5,37 +5,47 @@ const Dataset = require("atlas-dataset");
 const { isPos, isFn, msg } = require("./util")
 
 // rule: if class has single public method, use a factory instead.
-module.exports = ({log = true, stat = false, dec = 3, n = 1}={}) => {
+module.exports = ({log = true, dec = 3, n = 1}={}) => {
   if (!isPos(n)) throw new Error("n must be non-zero, finite num");
   const report = (task, data) => {
+    const isStat = data.size() > 1;
     if (log){
       const name = task.name || "task";
-      let msg = `${name} x ${n} took ${fmt(data.sum(), dec)}`;
-      if (stat) msg += ` (${fmt(data.median(), dec)} +/- ${fmt(data.mad(), dec)})`;
+      let msg = `${task.name || "task"} x ${n}`;
+      if (isStat) msg += ` (x ${data.size()})`
+      msg += ` took ${fmt(data.sum(), dec)}`;
+      if (isStat) msg += ` (${fmt(data.median(), dec)} +/- ${fmt(data.mad(), dec)})`;
       console.log(msg)
     }
-    return stat ? data.snapshot() : data.sum()
+    return isStat ? data.snapshot() : data.sum()
   }
-  return (task, cb) => {
+  return (task, samples, cb) => {
+    if (isFn(samples)) cb = samples, samples = 1;
+    samples = samples || 1
+    if (!isPos(samples)) 
+      throw new Error("samples must be non-zero, finite num");
     if (!isFn(task)) 
       throw new Error("task must be fn");
     const data = new Dataset([])
     if (!cb){
-      for (let i = n; i--;) {
-        const t0 = hrtime();
-        task();
+      while(samples--){
+        let t0 = hrtime(), i = n;
+        while(i--) task();
         data.add(hrtime(t0))
       }
       return report(task, data);
     }
-    const errs = [], queue = new Queue(1, () => cb(errs, report(task, data)));
-    for (let i = n; i--;) queue.push(done => {
-      const t0 = hrtime();
-      task(err => {
-        data.add(hrtime(t0));
-        err && errs.push(err);
-        done();
-      })
+    const errs = []
+    const sampleQ = new Queue(1, () => cb(errs, report(task, data)));
+    while(samples--) sampleQ.push(endSample => {
+      let i = n, t0;
+      const taskQ = new Queue(1, () => {
+        data.add(hrtime(t0)), endSample()
+      });
+      t0 = hrtime();
+      while(i--) taskQ.push(endTask => task(err => {
+        err && errs.push(err), endTask();
+      }));
     })
   }
 }

--- a/test/Timer.test.js
+++ b/test/Timer.test.js
@@ -109,6 +109,13 @@ describe("Timer", function(){
             testDone();
           })
         })
+        it("should return time diff in the done callback if samples is 1", function(testDone){
+          const task = makeAsyncJob(20);
+          Timer({n: 10, log:false})(task, 1, (errs, elapsed) => {
+            expect(elapsed).to.be.a("number");
+            testDone();
+          })
+        })
         it("should return correct stats in the done callback if multiple samples", function(testDone){
           const n = 10, t0 = 5, t1 = 10, task = makeAsyncJob(5), s = 3
           let calledTask = 0, calledTime = 0;
@@ -176,6 +183,10 @@ describe("Timer", function(){
           })
           const deltaTime = Timer({n, log:false})(() => calledTask++);
           expect(deltaTime).to.equal(t1-t0)
+        }))
+        it("should return the time diff if samples is 1", cleanup(function(){
+          const deltaTime = Timer({n: 10, log:false})(() => {}, 1);
+          expect(deltaTime).to.be.a("number")
         }))
         it("should return the correct stats if multiple samples", cleanup(function(){
           const t0 = 5, t1 = 10, n = 10, s = 3


### PR DESCRIPTION
Deprecate `stats: true` in favor of specifying the number of samples when timer is called on a task, automatically return the stats if the number of samples is greater than 1:

```
const Timer = require("atlas-basic-timer")
const time = Timer({n:1000});
...
const stats = time(myTask, 50) // 50 samples means 1000*50 calls to myTask, since n is 1000
```